### PR TITLE
Cache referral responses, not just authoritative ones

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,5 @@
+use crate::cache::CacheResponse::{Authoritative, Referral};
+use crate::target::get_ns_name;
 use hickory_proto::rr::{Name, RData, Record, RecordType};
 use lru::LruCache;
 use std::collections::{HashMap, HashSet};
@@ -6,7 +8,7 @@ use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 #[derive(Debug)]
 pub(crate) struct Cache<K: Hash + Eq, V> {
@@ -25,8 +27,8 @@ impl<K: Hash + Eq + Debug, V: Clone + Debug> Cache<K, V> {
         Cache { lru: Mutex::new(LruCache::new(capacity)) }
     }
     #[instrument(name = "cache-store", skip(self))]
-    pub(crate) fn store_with_ttl(&self, question: K, value: V, valid_before: Instant) {
-        self.lru.lock().unwrap().put(question, ValueWithTTL { value, valid_before });
+    pub(crate) fn store_with_ttl(&self, key: K, value: V, valid_before: Instant) {
+        self.lru.lock().unwrap().put(key, ValueWithTTL { value, valid_before });
     }
 
     #[instrument(name = "cache-get", skip(self), fields(hit = false, expired = false))]
@@ -54,6 +56,13 @@ pub(crate) struct Query {
     pub record_type: RecordType,
 }
 
+#[derive(Debug, PartialEq)]
+pub(crate) enum CacheResponse {
+    Authoritative(Vec<Record>),
+    Referral(Vec<Record>, Vec<Record>),
+    None,
+}
+
 /// Some convenient methods for Caches that holds DNS data
 impl DnsCache {
     /// extracts the ttl from the Record to be stored, to make it a bit more ergonomic to use
@@ -66,6 +75,8 @@ impl DnsCache {
         self.store_with_ttl(query, value, now + min_ttl);
     }
 
+    /// a version of store that will validate referral style responses and
+    /// create keys from name_server and glue records
     pub(crate) fn store_referral(
         &self,
         name_servers: Vec<Record>,
@@ -84,9 +95,49 @@ impl DnsCache {
         }
     }
 
-    pub(crate) fn get_and_update_ttl(&self, query: &Query, now: Instant) -> Option<Vec<Record>> {
+    fn get_and_update_ttl(&self, query: &Query, now: Instant) -> Option<Vec<Record>> {
         self.get_with_remaining_ttl(query, now).map(update_ttl)
     }
+
+    pub(crate) fn get_best_record(&self, query: &Query, now: Instant) -> CacheResponse {
+        if let Some(records) = self.get_and_update_ttl(query, now) {
+            return Authoritative(records);
+        }
+        for parent in parents(&query.to_resolve) {
+            let q = Query { to_resolve: parent, record_type: RecordType::NS };
+            if let Some(records) = self.get_and_update_ttl(&q, now) {
+                return Referral(records.clone(), self.fetch_glue(&records, now));
+            }
+        }
+        CacheResponse::None
+    }
+
+    fn fetch_glue(&self, name_servers: &Vec<Record>, now: Instant) -> Vec<Record> {
+        let mut result = Vec::with_capacity(name_servers.len());
+        for ns in name_servers {
+            if let Ok(name) = get_ns_name(ns) {
+                let query = Query { to_resolve: name.clone(), record_type: RecordType::A };
+                if let Some(records) = self.get_and_update_ttl(&query, now) {
+                    result.extend(records);
+                }
+            } else {
+                warn!(%ns, "Invalid NS record retrieved from cache")
+            }
+        }
+        result
+    }
+}
+
+fn parents(name: &Name) -> Vec<Name> {
+    let mut result = Vec::new();
+    // the zero label Name is a special case. Has no parents
+    let mut name = name.base_name();
+    while name.num_labels() > 0 {
+        let another = name.base_name();
+        result.push(name);
+        name = another
+    }
+    result
 }
 
 fn make_referral_query(records: &Vec<Record>) -> HashMap<Query, Vec<Record>> {
@@ -140,14 +191,29 @@ fn update_ttl(item: (Vec<Record>, Duration)) -> Vec<Record> {
 
 #[cfg(test)]
 mod tests {
-    use crate::cache::{eligible, make_referral_query, update_ttl, Cache, DnsCache, Query};
+    use crate::cache::CacheResponse::{Authoritative, Referral};
+    use crate::cache::{
+        eligible, make_referral_query, parents, update_ttl, Cache, DnsCache, Query,
+    };
     use crate::{a, ns};
     use anyhow::Result;
     use hickory_proto::rr::{rdata, Name, RData, Record, RecordType};
     use std::collections::HashMap;
     use std::num::NonZeroUsize;
+    use std::str::FromStr;
     use std::time::{Duration, Instant};
 
+    macro_rules! query {
+        ($name:expr, $record_type:expr) => {
+            Query { to_resolve: $name.parse()?, record_type: $record_type }
+        };
+    }
+
+    macro_rules! name {
+        ($name:expr) => {
+            Name::from_str($name)?
+        };
+    }
     #[test]
     fn test_cache() {
         let capacity: NonZeroUsize = NonZeroUsize::new(5).unwrap();
@@ -184,11 +250,6 @@ mod tests {
         let result = update_ttl((vec![record, another], Duration::from_secs(42)));
         assert!(result.into_iter().map(|r| r.ttl()).all(|ttl| ttl == 42));
         Ok(())
-    }
-    macro_rules! query {
-        ($name:expr, $record_type:expr) => {
-            Query { to_resolve: $name.parse()?, record_type: $record_type }
-        };
     }
 
     #[test]
@@ -289,6 +350,62 @@ mod tests {
         let result = cache.get_and_update_ttl(&query!("com", RecordType::NS), Instant::now());
         assert_eq!(Some(vec![ns!("com", "a.com"), ns!("com", "b.com")]), result);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_best_record_authoritative() -> Result<()> {
+        let cache = DnsCache::new(NonZeroUsize::new(1).unwrap());
+        let q = query!("example.com", RecordType::A);
+        cache.store(q.clone(), vec![a!("example.com", "127.0.0.1")], Instant::now());
+        // direct hit
+        let result = cache.get_best_record(&q, Instant::now());
+        assert_eq!(Authoritative(vec![a!("example.com", "127.0.0.1")]), result);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_best_record_referral() -> Result<()> {
+        let cache = DnsCache::new(NonZeroUsize::new(3).unwrap());
+        cache.store_referral(
+            vec![ns!("com.", "a.com."), ns!("com.", "b.com.")],
+            vec![a!("a.com.", "127.0.0.1"), a!("b.com.", "127.0.0.3")],
+            &"example.com.".parse()?,
+            Instant::now(),
+        );
+
+        let result = cache.get_and_update_ttl(&query!("com.", RecordType::NS), Instant::now());
+        assert_eq!(Some(vec![ns!("com.", "a.com."), ns!("com.", "b.com.")]), result);
+
+        let cache = DnsCache::new(NonZeroUsize::new(100).unwrap());
+        cache.store_referral(
+            vec![ns!("com.", "ns0.com."), ns!("com.", "ns1.com.")],
+            vec![a!["ns0.com.", "127.0.0.1"], a!("ns1.com.", "127.0.0.2")],
+            &Name::from_str("foo.com.")?,
+            Instant::now(),
+        );
+
+        let result = cache.get_best_record(&query!("bar.com", RecordType::A), Instant::now());
+        assert_eq!(
+            Referral(
+                vec![ns!("com", "ns0.com"), ns!("com", "ns1.com")],
+                vec![a!["ns0.com", "127.0.0.1"], a!("ns1.com", "127.0.0.2")]
+            ),
+            result
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parents() -> Result<()> {
+        assert!(parents(&name!("")).is_empty());
+
+        assert_eq!(vec![name!("b.com"), name!("com")], parents(&name!("a.b.com")));
+        assert_eq!(
+            vec![name!("b.c.com"), name!("c.com"), name!("com")],
+            parents(&name!("a.b.c.com"))
+        );
         Ok(())
     }
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -77,7 +77,7 @@ fn find_in_glue(name: &Name, glue: &[Record]) -> Option<IpAddr> {
         .next()
 }
 
-fn get_ns_name(record: &Record) -> Result<&Name, ResolutionError> {
+pub(crate) fn get_ns_name(record: &Record) -> Result<&Name, ResolutionError> {
     if record.record_type() != RecordType::NS {
         return Err(ServFail("Record type not NS".to_string()));
     }


### PR DESCRIPTION
Changed the caching logic to not only store authoritative reponses but all the data that is learned when doing a lookup.